### PR TITLE
Set name value to filename when name is undefined

### DIFF
--- a/AssetsAppendWebpackPlugin.js
+++ b/AssetsAppendWebpackPlugin.js
@@ -9,6 +9,9 @@ class WebpackBundleAppend {
   }
 
   append (compilation, name, filename) {
+    if (typeof name === 'undefined') {
+      name = filename;
+    }
     this.snippets.forEach((snippet) => {
       if (snippet.match && !name.match(snippet.match)) { return; }
 


### PR DESCRIPTION
In some cases, the chunk name is undefined which leads to errors

Example:
```
name: undefined
filename: 'extract-text-webpack-plugin-output-filename'
```